### PR TITLE
Add continuous integration with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ dist: xenial
 
 node_js:
  - "node"
+ - "12"
  - "10"
  - "8"
- - "6"
 
 env:
  - CONFIG: 'package-darwin'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 dist: xenial
 
 node_js:
-# - "node"
+ - "node"
  - "10"
 
 env:
@@ -11,9 +11,5 @@ env:
  - CONFIG: 'package-darwin'
  - CONFIG: 'package-linux'
  - CONFIG: 'package-win32'
- 
-before_install:
- - npm install webpack
- - npm install webpack-cli
  
 script: npm run $CONFIG

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,4 @@ env:
  - CONFIG: 'package-linux'
  - CONFIG: 'package-win32'
 
-install:
- - npm install
- - npm --dev update
-
 script: npm run $CONFIG

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: node_js
 dist: xenial
 
 node_js:
- - "node"
+# - "node"
  - "10"
  - "8"
- - "6"
+# - "6"
 
 env:
  - CONFIG: 'build-release'
@@ -14,6 +14,8 @@ env:
  - CONFIG: 'package-linux'
  - CONFIG: 'package-win32'
 
-before_install: npm --dev update
+install:
+ - npm install
+ - npm --dev update
 
 script: npm run $CONFIG

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 dist: xenial
 
 node_js:
- #- "node"
- #- "10"
+ - "node"
+ - "10"
  - "8"
  - "6"
 
@@ -13,5 +13,7 @@ env:
  - CONFIG: 'package-darwin'
  - CONFIG: 'package-linux'
  - CONFIG: 'package-win32'
- 
+
+before_install: npm --dev update
+
 script: npm run $CONFIG

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ env:
  - CONFIG: 'package-linux'
  - CONFIG: 'package-win32'
  
-install:
- - npm i -D webpack-cli @webpack-cli/update
- - npm install
+before_install:
+ - npm install webpack
+ - npm install webpack-cli
  
 script: npm run $CONFIG

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: node_js
 dist: xenial
 
 node_js:
- - "node"
- - "10"
+ #- "node"
+ #- "10"
+ - "8"
+ - "6"
 
 env:
  - CONFIG: 'build-release'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+
+env:
+ - CONFIG: 'build-release'
+ - CONFIG: 'build-watch'
+ - CONFIG: 'package-darwin'
+ - CONFIG: 'package-linux'
+ - CONFIG: 'package-win32'
+ 
+script: npm run $CONFIG

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: node_js
 dist: xenial
 
 node_js:
-# - "node"
+ - "node"
  - "10"
  - "8"
-# - "6"
+ - "6"
 
 env:
  - CONFIG: 'build-release'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 dist: xenial
 
 node_js:
- - "node"
+# - "node"
  - "10"
 
 env:
@@ -11,5 +11,9 @@ env:
  - CONFIG: 'package-darwin'
  - CONFIG: 'package-linux'
  - CONFIG: 'package-win32'
+ 
+install:
+ - npm i -D webpack-cli @webpack-cli/update
+ - npm install
  
 script: npm run $CONFIG

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+dist: xenial
 
 node_js:
  - "node"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ node_js:
  - "6"
 
 env:
- - CONFIG: 'build-release'
- - CONFIG: 'build-watch'
  - CONFIG: 'package-darwin'
  - CONFIG: 'package-linux'
  - CONFIG: 'package-win32'
+ - CONFIG: 'build-release'
+ - CONFIG: 'build-watch'
 
 script: npm run $CONFIG

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 
+node_js:
+ - "node"
+ - "10"
+
 env:
  - CONFIG: 'build-release'
  - CONFIG: 'build-watch'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [AOM Analyzer](http://aomanalyzer.org)
+# [AOM Analyzer](http://aomanalyzer.org) [![Travis Build Status](https://travis-ci.org/mbebenita/aomanalyzer.svg?branch=master)](https://travis-ci.org/mbebenita/aomanalyzer)
 
 ## Install & Build
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "electron-packager": "^11.2.0",
     "ts-loader": "^2.0.3",
     "typescript": "^2.2.2",
-    "webpack": "^2.3.3"
+    "webpack": "^4.28.0"
   },
   "dependencies": {
     "argparse": "^1.0.9",

--- a/package.json
+++ b/package.json
@@ -15,23 +15,23 @@
   "author": "Michael Bebenita",
   "license": "ISC",
   "devDependencies": {
-    "@types/react": "16.0.15",
-    "@types/react-dom": "16.0.2",
+    "@types/react": "^16.0.15",
+    "@types/react-dom": "^16.0.2",
     "electron-packager": "^11.2.0",
     "ts-loader": "^2.0.3",
     "typescript": "^2.2.2",
-    "webpack": "^4.28.0"
+    "webpack": "^3.10.0"
   },
   "dependencies": {
     "argparse": "^1.0.9",
     "electron": "^4.0.2",
     "electron-packager-dummy-wine": "^1.0.2",
     "file-saver": "^1.3.3",
-    "material-ui": "0.19.4",
-    "react": "16.0.0",
-    "react-dom": "16.0.0",
-    "react-input-autosize": "1.1.0",
-    "react-select": "1.0.0-rc.10",
-    "react-tap-event-plugin": "3.0.1"
+    "material-ui": "^0.19.4",
+    "react": "^16.0.2",
+    "react-dom": "^16.0.2",
+    "react-input-autosize": "^1.1.0",
+    "react-select": "^1.0.0-rc.10",
+    "react-tap-event-plugin": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/react": "^16.0.15",
     "@types/react-dom": "^16.0.2",
-    "electron-packager": "^11.2.0",
+    "electron-packager": "^12.2.0",
     "ts-loader": "^2.0.3",
     "typescript": "^2.2.2",
     "webpack": "^3.10.0"

--- a/package.json
+++ b/package.json
@@ -8,23 +8,23 @@
     "build-watch": "webpack --watch --config config/webpack.config.js",
     "build-debug": "webpack --display-reasons --progress --config config/webpack.config.js",
     "build-release": "webpack -p --config config/webpack.config.js",
-    "package-darwin": "electron-packager . --platform=darwin --arch=x64 --electron-version=2.0.8 --overwrite --icon=vomit.icns --out=release_builds --tmpdir=/tmp",
-    "package-linux": "electron-packager . --platform=linux --arch=x64 --electron-version=2.0.8 --overwrite  --out=release_builds --tmpdir=/tmp",
-    "package-win32": "electron-packager . --platform=win32 --arch=x64 --electron-version=2.0.8 --overwrite  --out=release_builds --tmpdir=/tmp"
+    "package-darwin": "electron-packager . --platform=darwin --arch=x64 --electron-version=4.0.2 --overwrite --icon=vomit.icns --out=release_builds --tmpdir=/tmp",
+    "package-linux": "electron-packager . --platform=linux --arch=x64 --electron-version=4.0.2 --overwrite  --out=release_builds --tmpdir=/tmp",
+    "package-win32": "electron-packager . --platform=win32 --arch=x64 --electron-version=4.0.2 --overwrite  --out=release_builds --tmpdir=/tmp"
   },
   "author": "Michael Bebenita",
   "license": "ISC",
   "devDependencies": {
     "@types/react": "16.0.15",
     "@types/react-dom": "16.0.2",
-    "electron-packager": "^8.7.2",
+    "electron-packager": "^11.2.0",
     "ts-loader": "^2.0.3",
     "typescript": "^2.2.2",
     "webpack": "^2.3.3"
   },
   "dependencies": {
     "argparse": "^1.0.9",
-    "electron": "^2.0.8",
+    "electron": "^4.0.2",
     "electron-packager-dummy-wine": "^1.0.2",
     "file-saver": "^1.3.3",
     "material-ui": "0.19.4",


### PR DESCRIPTION
Adds continuous integration with Travis. Travis needs to be [enabled](https://github.com/marketplace/travis-ci) in the GitHub Marketplace.

I updated some dependencies to get packages build succesfully on Node.js 10 and 11. 

One main error keeps showing up during the `build-release` and `build-watch` jobs is in `webpack -p --config config/webpack.config.js`. You can see Travis runs of EwoutH/aomanalyzer [here](https://travis-ci.com/EwoutH/aomanalyzer/builds/98574949). You can also see an early run before I updated dependencies [here](https://travis-ci.com/EwoutH/aomanalyzer/builds/98570344).
```
 [335] ./src/main.tsx 4.85 kB {0} [built]
 [336] ./src/worker.ts 8.28 kB {1} [built] [1 error]
    + 324 hidden modules
ERROR in ./src/worker.ts
(3,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'TextDecoder' must be of type '{ new (label?: string, options?: TextDecoderOptions): TextDecoder; prototype: TextDecoder; }', but here has type 'any'.
```